### PR TITLE
change height resolution to 0.1mm

### DIFF
--- a/parametric_base_generator.scad
+++ b/parametric_base_generator.scad
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 //height (thickness) of this tray
-height = 4;
+height = 4;//.1
 //base width 
 base_width = 25;
 //base length 

--- a/parametric_tray_generator.scad
+++ b/parametric_tray_generator.scad
@@ -16,7 +16,7 @@ cols = 6;
 //Number of rows for this tray
 rows = 7;
 //heigh (thickness) of this tray
-height = 5;
+height = 5;//.1
 //new base width 
 new_base_width = 25;
 //new base length 


### PR DESCRIPTION
Changes height resolution in parametric_tray_generator.scad and parametric_base_generator.scad to 0.1 mm so that heights in between integers can be set.

I did this for myself wanting 3.5 mm high bases and thought others might want the same.