### PR TITLE
Add support for parallel slotta (cavalry type)

### DIFF
--- a/parametric_base_generator.json
+++ b/parametric_base_generator.json
@@ -71,6 +71,34 @@
             "magnets_height": "0.1",
             "slotta_type": "0",
             "slotta_width": "2"
+        },
+        "25x50 slotta": {
+            "base_length": "50",
+            "base_type": "0",
+            "base_width": "25",
+            "height": "4",
+            "height_offset": "1.3",
+            "inset": "1",
+            "magnets_diameter": "0.1",
+            "magnets_height": "0.1",
+            "slotta_gap": "2.5",
+            "slotta_length": "35",
+            "slotta_type": "4",
+            "slotta_width": "2"
+        },
+        "30x60 slotta": {
+            "base_length": "60",
+            "base_type": "0",
+            "base_width": "30",
+            "height": "4",
+            "height_offset": "1.3",
+            "inset": "1",
+            "magnets_diameter": "0.1",
+            "magnets_height": "0.1",
+            "slotta_gap": "2.5",
+            "slotta_length": "35",
+            "slotta_type": "4",
+            "slotta_width": "2"
         }
     },
     "fileFormatVersion": "1"

--- a/parametric_base_generator.scad
+++ b/parametric_base_generator.scad
@@ -32,7 +32,9 @@ slotta_width = 2;//0.1
 //slotta hole length
 slotta_length = 18;//0.1
 //slotta type
-slotta_type = "0"; // [0:None, 1:Parallel Center, 2:Parallel 3/4, 3:Diagonal]
+slotta_type = "0"; // [0:None, 1:Parallel Center, 2:Parallel 3/4, 3:Diagonal, 4:Cavalry]
+//slotta gap (cavalry type only)
+slotta_gap = 2.5;//0.1
 
 module tray(offset, zOffset, height, base_width, base_length, inset) {
     
@@ -103,7 +105,20 @@ module slotta (base_width, base_length,slotta_width,slotta_height, slotta_type, 
             cube(size = [slotta_length,slotta_width,slotta_height+0.2]);
                     
         }
-    }    
+    }
+
+    if(slotta_type == "4"){
+        
+        translate( 
+            [(base_width / 2) - (slotta_width / 2) - slotta_gap,(base_length - slotta_length)/2, -0.1]
+        )
+        cube(size = [slotta_width,slotta_length,slotta_height+0.2]);
+
+        translate( 
+            [(base_width / 2) - (slotta_width / 2) + slotta_gap,(base_length - slotta_length)/2, -0.1]
+        )
+        cube(size = [slotta_width,slotta_length,slotta_height+0.2]);
+    }
 }
 
 module magnets_holes (base_width, base_length, magnets_height, magnets_diameter) {   


### PR DESCRIPTION
Allows you to create cavalry slotta bases with two parallel slots, like a standard GW cavalry base.  Includes presets for light and heavy cavalry variants.